### PR TITLE
Created the link for web2 iq to starknet identity

### DIFF
--- a/src/contracts/leaderboard.cairo
+++ b/src/contracts/leaderboard.cairo
@@ -30,8 +30,11 @@ mod Leaderboard {
             let wallet = get_caller_address();
             let idx = self.wallet_to_index.get(wallet).unwrap_or(0);
             if idx != 0 {
-                // Already submitted, revert
-                panic!("Already submitted");
+                // Overwrite existing entry
+                let entry = LeaderboardEntry { wallet, proof_hash, percentile };
+                self.entries.set(idx - 1, entry); // idx is 1-based
+                emit ScoreSubmitted { wallet, proof_hash, percentile };
+                return;
             }
             let entry = LeaderboardEntry { wallet, proof_hash, percentile };
             self.entries.append(entry);


### PR DESCRIPTION
Created the link for web2 iq to starknet identity to Associate user IQ scores with their StarkNet wallet to build a Web3-native reputation layer and all criteria were met.
Added walletAddress field in backend user model

Verified ownership via message signing

Stored StarkNet address on assessment completion

Optional: publish public scores on-chain for profile visibility

closes[#13]

